### PR TITLE
gh-122957: Fix test flakiness in free-thread build

### DIFF
--- a/Lib/test/test_asyncio/test_threads.py
+++ b/Lib/test/test_asyncio/test_threads.py
@@ -30,7 +30,9 @@ class ToThreadTests(unittest.IsolatedAsyncioTestCase):
         func.assert_called_once()
 
     async def test_to_thread_concurrent(self):
-        func = mock.Mock()
+        calls = []
+        def func():
+            calls.append(1)
 
         futs = []
         for _ in range(10):
@@ -38,7 +40,7 @@ class ToThreadTests(unittest.IsolatedAsyncioTestCase):
             futs.append(fut)
         await asyncio.gather(*futs)
 
-        self.assertEqual(func.call_count, 10)
+        self.assertEqual(sum(calls), 10)
 
     async def test_to_thread_args_kwargs(self):
         # Unlike run_in_executor(), to_thread() should directly accept kwargs.


### PR DESCRIPTION
Fix #122957.

Locally I tested this by running the test 1000 times with the diff below. It fails around 10-20 times out of 1000 on `main` and does not fail out of 1000 times on `main`.

```diff
diff --git a/Lib/test/test_asyncio/test_threads.py b/Lib/test/test_asyncio/test_threads.py
index 774380270a7..8504544aaba 100644
--- a/Lib/test/test_asyncio/test_threads.py
+++ b/Lib/test/test_asyncio/test_threads.py
@@ -63,4 +63,10 @@ def get_ctx():
 
 
 if __name__ == "__main__":
-    unittest.main()
+    nb_tests = 1000
+    suite = unittest.TestSuite(
+        [ToThreadTests("test_to_thread_concurrent") for _ in range(nb_tests)]
+    )
+
+    test_runner = unittest.TextTestRunner()
+    test_runner.run(suite)
``` 
